### PR TITLE
Log result URL at the end of run

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -136,7 +136,7 @@ var sr = __importStar(__nccwpck_require__(6889));
 var inputs_1 = __nccwpck_require__(6180);
 function run() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, wizClientId, wizClientSecret, wizApiEndpointUrl, wizApiIdP, image, customPolicies, pull, fail_1, wizCredentials, wizcli, _b, scanId, scanPassed, result, summary, error_1, error_2;
+        var _a, wizClientId, wizClientSecret, wizApiEndpointUrl, wizApiIdP, image, customPolicies, pull, fail_1, wizCredentials, wizcli, _b, scanId, scanPassed, result, summary, error_1, resultUrlBase, resultUrlHash, resultUrl, error_2;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
@@ -182,11 +182,16 @@ function run() {
                     }
                     return [3, 9];
                 case 9:
+                    resultUrlBase = "https://app.wiz.io/reports/cicd-scans";
+                    resultUrlHash = fixedEncodeURIComponent("~(cicd_scan~'".concat(scanId, ")"));
+                    resultUrl = "".concat(resultUrlBase, "#").concat(resultUrlHash);
                     if (scanPassed) {
+                        core.info("Scan passed: ".concat(resultUrl));
                         core.setOutput("scan-id", scanId);
                         core.setOutput("scan-result", "success");
                     }
                     else {
+                        core.warning("Scan failed: ".concat(resultUrl));
                         core.setOutput("scan-id", scanId);
                         core.setOutput("scan-result", "failed");
                         if (fail_1) {
@@ -209,6 +214,11 @@ function run() {
                 case 11: return [2];
             }
         });
+    });
+}
+function fixedEncodeURIComponent(str) {
+    return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+        return "%" + c.charCodeAt(0).toString(16);
     });
 }
 run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,10 +51,16 @@ async function run() {
       }
     }
 
+    const resultUrlBase = "https://app.wiz.io/reports/cicd-scans";
+    const resultUrlHash = fixedEncodeURIComponent(`~(cicd_scan~'${scanId})`);
+    const resultUrl = `${resultUrlBase}#${resultUrlHash}`;
+
     if (scanPassed) {
+      core.info(`Scan passed: ${resultUrl}`);
       core.setOutput("scan-id", scanId);
       core.setOutput("scan-result", "success");
     } else {
+      core.warning(`Scan failed: ${resultUrl}`);
       core.setOutput("scan-id", scanId);
       core.setOutput("scan-result", "failed");
 
@@ -75,6 +81,13 @@ async function run() {
       core.setFailed("Non-Error exception");
     }
   }
+}
+
+// https://stackoverflow.com/a/62436236
+function fixedEncodeURIComponent(str: string): string {
+  return encodeURIComponent(str).replace(/[!'()*]/g, (c) => {
+    return "%" + c.charCodeAt(0).toString(16);
+  });
 }
 
 run();


### PR DESCRIPTION
This link is already present in the CLI output and our build summary.
Both of these can be insufficient:

1. The CLI output is not URI-encoded, and the characters used makes the
   link unclickable from build logs. A slow copy/paste is necessary.
2. It's a common issue that looking at a particular build's logs is
   where users start, and information in the Summary is never seen
3. The Summary content may not be present if the action is not
   configured with Wiz API access

So, logging it separately and URI-encoded should be a nice
quality-of-life improvement.

---

The difference between encoding (L8141) or not (L8138):

![](https://files.pbrisbin.com/screenshots/screenshot.1524993.png)