### PR TITLE
Don't run CI on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: main
 
 jobs:
   build:


### PR DESCRIPTION
There's nothing that CI would be used for or gate, it's unnecessary.