### PR TITLE
fix(CLI-v1): Use right URLs to download the CLI v1

### DIFF
--- a/src/wiz-cli.test.ts
+++ b/src/wiz-cli.test.ts
@@ -31,7 +31,7 @@ describe("getWizInstallUrl", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     Object.defineProperty(process, "arch", { value: "x64" });
     expect(getWizInstallUrl()).toBe(
-      "https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64",
+      "https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64",
     );
   });
 
@@ -39,7 +39,7 @@ describe("getWizInstallUrl", () => {
     Object.defineProperty(process, "platform", { value: "linux" });
     Object.defineProperty(process, "arch", { value: "arm64" });
     expect(getWizInstallUrl()).toBe(
-      "https://downloads.wiz.io/wizcli/latest/wizcli-linux-arm64",
+      "https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-arm64",
     );
   });
 
@@ -47,7 +47,7 @@ describe("getWizInstallUrl", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
     Object.defineProperty(process, "arch", { value: "x64" });
     expect(getWizInstallUrl()).toBe(
-      "https://downloads.wiz.io/wizcli/latest/wizcli-darwin-amd64",
+      "https://downloads.wiz.io/v1/wizcli/latest/wizcli-darwin-amd64",
     );
   });
 
@@ -55,7 +55,7 @@ describe("getWizInstallUrl", () => {
     Object.defineProperty(process, "platform", { value: "darwin" });
     Object.defineProperty(process, "arch", { value: "arm64" });
     expect(getWizInstallUrl()).toBe(
-      "https://downloads.wiz.io/wizcli/latest/wizcli-darwin-arm64",
+      "https://downloads.wiz.io/v1/wizcli/latest/wizcli-darwin-arm64",
     );
   });
 
@@ -63,7 +63,7 @@ describe("getWizInstallUrl", () => {
     Object.defineProperty(process, "platform", { value: "win32" });
     Object.defineProperty(process, "arch", { value: "x64" });
     expect(getWizInstallUrl()).toBe(
-      "https://downloads.wiz.io/wizcli/latest/wizcli-windows-amd64.exe",
+      "https://downloads.wiz.io/v1/wizcli/latest/wizcli-windows-amd64.exe",
     );
   });
 

--- a/src/wiz-cli.ts
+++ b/src/wiz-cli.ts
@@ -89,21 +89,21 @@ export function parseScanId(str: string): string | null {
 export function getWizInstallUrl(): string {
   switch (process.platform) {
     case "win32":
-      return "https://downloads.wiz.io/wizcli/latest/wizcli-windows-amd64.exe";
+      return "https://downloads.wiz.io/v1/wizcli/latest/wizcli-windows-amd64.exe";
     case "darwin":
       switch (process.arch) {
         case "x64":
-          return "https://downloads.wiz.io/wizcli/latest/wizcli-darwin-amd64";
+          return "https://downloads.wiz.io/v1/wizcli/latest/wizcli-darwin-amd64";
         case "arm64":
-          return "https://downloads.wiz.io/wizcli/latest/wizcli-darwin-arm64";
+          return "https://downloads.wiz.io/v1/wizcli/latest/wizcli-darwin-arm64";
       }
       break;
     case "linux":
       switch (process.arch) {
         case "x64":
-          return "https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64";
+          return "https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64";
         case "arm64":
-          return "https://downloads.wiz.io/wizcli/latest/wizcli-linux-arm64";
+          return "https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-arm64";
       }
   }
 


### PR DESCRIPTION
This pull request updates the URLs generated by the `getWizInstallUrl` function to include the `/v1/` path segment, ensuring that all download links point to the correct versioned location. Corresponding tests have also been updated to reflect this change.

**Update to Wiz CLI download URLs:**

* Updated the `getWizInstallUrl` function in `src/wiz-cli.ts` to generate URLs with `/v1/` in the path for all supported platforms and architectures.
* Modified related tests in `src/wiz-cli.test.ts` to expect the new `/v1/` URLs.

Please treat this as critical. The URLs are not downloading the true “latest” Wiz CLI globally, so this action is still pulling a 0.x version. That’s why we keep seeing the warning:
“WARNING: WizCLI 0.X will reach End of Support on April 15, 2026. Please migrate to 1.X now.”
Today is the last day to update the CLI before 0.x reaches end of support.