### PR TITLE
chore(docs): update version in README.md examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with the Wiz CLI.
 
 ```yaml
 - run: docker build --tag myimage .
-- uses: freckle/wiz-action@v1
+- uses: freckle/wiz-action@v2
   with:
     wiz-client-id: ${{ secrets.WIZ_CLIENT_ID }}
     wiz-client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}
@@ -25,7 +25,7 @@ with the Wiz CLI.
     tags: ${{ steps.meta.outputs.tags }}
     load: true # required so we can scan it
 
-- uses: freckle/wiz-action@v1
+- uses: freckle/wiz-action@v2
   with:
     wiz-client-id: ${{ secrets.WIZ_CLIENT_ID }}
     wiz-client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}


### PR DESCRIPTION
It's important to use `@v2` because `@v1` uses old CLI installation URLs which will stop working soon.