### PR TITLE
fix: skip auth step, pass credentials to scan

### DIFF
--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - id: scan
-        name: Scan statsd/statsd:v0.9.0 with wiz
+      - name: Scan statsd/statsd:v0.9.0 with service account credentials
         uses: ./
         with:
           wiz-client-id: ${{ secrets.WIZ_CLIENT_ID }}
@@ -29,6 +28,17 @@ jobs:
           custom-policies: tvm_automation_policy
           fail: false
           pull: true
+
+      - id: scan
+        name: Scan statsd/statsd:v0.9.0 with deployment credentials
+        uses: ./
+        with:
+          wiz-client-id: ${{ secrets.WIZ_V1_CLIENT_ID }}
+          wiz-client-secret: ${{ secrets.WIZ_V1_CLIENT_SECRET }}
+          wiz-api-endpoint-url: ${{ vars.WIZ_API_ENDPOINT_URL }}
+          image: statsd/statsd:v0.9.0 # has many, many CVEs
+          custom-policies: tvm_automation_policy
+          fail: false
 
       - name: Verify Scan Id
         run: |

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,7 +1,8 @@
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: "conventionalcommits"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/release-notes-generator"
+    - preset: "conventionalcommits"
   - - "@semantic-release/github"
     - successCommentCondition: false
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -34315,19 +34315,13 @@ class WizCLI {
         this.wizcli = wizcli;
         this.credentials = credentials;
     }
-    async auth() {
-        const { clientId, clientSecret } = this.credentials;
-        await exec_exec(this.wizcli, [
-            "auth",
-            "--id",
-            clientId,
-            "--secret",
-            clientSecret,
-        ]);
-        return this;
-    }
     async scan(image, policies) {
-        const args = ["docker", "scan", "--image", image, "--no-style"].concat(policies ? ["--policy", policies] : []);
+        const { clientId, clientSecret } = this.credentials;
+        const args = ["docker", "scan", "--image", image]
+            .concat(["--no-style"])
+            .concat(["--client-id", clientId])
+            .concat(["--client-secret", clientSecret])
+            .concat(policies ? ["--policy", policies] : []);
         let scanId = null;
         const listener = (data) => {
             if (!scanId) {
@@ -34358,7 +34352,7 @@ async function getWizCLI(credentials) {
     const wizUrl = getWizInstallUrl();
     const wizcli = await downloadTool(wizUrl);
     await exec_exec("chmod", ["+x", wizcli]);
-    return new WizCLI(wizcli, credentials).auth();
+    return new WizCLI(wizcli, credentials);
 }
 const SCAN_ID_FORMAT = new RegExp("[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}");
 function parseScanId(str) {
@@ -34528,7 +34522,7 @@ async function run() {
             clientSecret: wizClientSecret,
         };
         if (pull) {
-            await exec_exec("docker", ["pull", image]);
+            await exec_exec("docker", ["pull", "--quiet", image]);
         }
         const wizcli = await getWizCLI(wizCredentials);
         const { scanId, scanPassed } = await wizcli.scan(image, customPolicies);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
 import * as exec from "@actions/exec";
 import * as core from "@actions/core";
 
-import * as wc from "./wiz-cli.js"
-import * as sr from "./scan-result.js"
-import { getInputs } from "./inputs.js"
+import * as wc from "./wiz-cli.js";
+import * as sr from "./scan-result.js";
+import { getInputs } from "./inputs.js";
 
 async function run() {
   try {
@@ -24,7 +24,7 @@ async function run() {
     };
 
     if (pull) {
-      await exec.exec("docker", ["pull", image]);
+      await exec.exec("docker", ["pull", "--quiet", image]);
     }
 
     const wizcli = await wc.getWizCLI(wizCredentials);

--- a/src/wiz-cli.ts
+++ b/src/wiz-cli.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as tc from "@actions/tool-cache";
-import type { WizCredentials } from "./wiz-config.js"
+import type { WizCredentials } from "./wiz-config.js";
 
 export type WizScanResult = {
   scanId: string | null;
@@ -17,24 +17,14 @@ class WizCLI {
     this.credentials = credentials;
   }
 
-  async auth(): Promise<WizCLI> {
+  async scan(image: string, policies: string | null): Promise<WizScanResult> {
     const { clientId, clientSecret } = this.credentials;
 
-    await exec.exec(this.wizcli, [
-      "auth",
-      "--id",
-      clientId,
-      "--secret",
-      clientSecret,
-    ]);
-
-    return this;
-  }
-
-  async scan(image: string, policies: string | null): Promise<WizScanResult> {
-    const args = ["docker", "scan", "--image", image, "--no-style"].concat(
-      policies ? ["--policy", policies] : [],
-    );
+    const args = ["docker", "scan", "--image", image]
+      .concat(["--no-style"])
+      .concat(["--client-id", clientId])
+      .concat(["--client-secret", clientSecret])
+      .concat(policies ? ["--policy", policies] : []);
 
     let scanId: string | null = null;
 
@@ -73,7 +63,7 @@ export async function getWizCLI(credentials: WizCredentials): Promise<WizCLI> {
   const wizUrl = getWizInstallUrl();
   const wizcli = await tc.downloadTool(wizUrl);
   await exec.exec("chmod", ["+x", wizcli]);
-  return new WizCLI(wizcli, credentials).auth();
+  return new WizCLI(wizcli, credentials);
 }
 
 // Example: "8221aac6-eae9-4867-bbb6-91fbd1092f45"


### PR DESCRIPTION
> [!NOTE]
> There are a few pre- and post-factor commits, so feel to review individually.

Wiz is deprecating the v0 CLI and Service Account credentials. Users are
required to migrate to Deployment credentials by June 1st.

https://docs.wiz.io/docs/set-up-wiz-cli#create-a-wiz-cli-deployment

The new, v1 CLI has some backwards-compatible support for the Service
Account credentials in the sub-commands we use here:

```sh
# What we used before this commit. Works with Service Account creds, but
# fails with Deployment creds. Shows a warning about auth not being needed.
auth <credentials>
docker scan --image <image>

# What everyone has to use after June 1st. Only works with Deployment creds,
# fails if given Service Account creds.
scan container-image <image> <credentials>

# Works with *either* Service Account or Deployment creds, shows no warnings, but
# expected to stop working after June 1st
docker scan --image <image> <credentials>
```

My plan is to leave `@v2` of this action in that state, and release
`@v3` as a breaking change that uses `scan container-image`, while also
moving to environment variables for the credentials.

Closes https://github.com/freckle/wiz-action/issues/405.