### PR TITLE
fix: handle null cicdScan when writing step summary

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,17 @@ async function run() {
         } else {
           core.warning("Error writing summary");
         }
+
+        try {
+          const fallback = sr.buildFallbackSummary(image, scanId);
+          await fallback.write();
+        } catch (fallbackError) {
+          if (fallbackError instanceof Error) {
+            core.warning(
+              `Error writing fallback summary: ${fallbackError.message}`,
+            );
+          }
+        }
       }
     }
 

--- a/src/scan-result.test.ts
+++ b/src/scan-result.test.ts
@@ -48,3 +48,22 @@ test("Passed with osPackages", () => {
 `,
   );
 });
+
+test("parse returns null when cicdScan is null", () => {
+  const body = fs
+    .readFileSync("test/scan-results/cicd-scan-null.json")
+    .toString();
+  expect(scanResult.parse(body)).toBeNull();
+});
+
+test("buildFallbackSummary writes link without resultJSON", () => {
+  const summary = scanResult
+    .buildFallbackSummary("myapp:latest", "scan-id-123")
+    .stringify();
+
+  expect(summary).toBe(
+    `<h1>Wiz scan report for myapp:latest</h1>
+<a href="https://app.wiz.io/reports/cicd-scans#~(cicd_scan~'scan-id-123)">View report on Wiz</a>
+`,
+  );
+});

--- a/src/scan-result.ts
+++ b/src/scan-result.ts
@@ -2,18 +2,21 @@ import * as core from "@actions/core";
 import type { HttpClient } from "@actions/http-client";
 import * as http from "@actions/http-client";
 
-import type { WizCredentials, WizIdP } from "./wiz-config.js";
+import type { WizIdP } from "./wiz-config.js";
 
 const JSON_HEADERS = {
   accept: "application/json",
   "content-type": "application/json",
 };
 
+const DEFAULT_FETCH_RETRIES = 5;
+const FETCH_RETRY_DELAY_MS = 2000;
+
 type CICDScanQL = {
   data: {
     cicdScan: {
       resultJSON: ScanResult;
-    };
+    } | null;
   };
 };
 
@@ -91,9 +94,27 @@ export async function fetch(
 ): Promise<ScanResult> {
   const client = new http.HttpClient();
   const token = await getAccessToken(client, apiIdP);
-  const body = await getCICDScanQL(client, token, apiEndpointUrl, scanId);
-  core.debug(`Raw body: ${body}`);
-  return parse(body);
+
+  for (let attempt = 1; attempt <= DEFAULT_FETCH_RETRIES; attempt++) {
+    const body = await getCICDScanQL(client, token, apiEndpointUrl, scanId);
+    core.debug(`Raw body (attempt ${attempt}): ${body}`);
+
+    const result = parse(body);
+    if (result) {
+      return result;
+    }
+
+    if (attempt < DEFAULT_FETCH_RETRIES) {
+      core.debug(
+        `cicdScan resultJSON not available yet, retrying in ${FETCH_RETRY_DELAY_MS}ms...`,
+      );
+      await sleep(FETCH_RETRY_DELAY_MS);
+    }
+  }
+
+  throw new Error(
+    "Wiz API returned no cicdScan resultJSON after scan completed. The scan report may not be available yet.",
+  );
 }
 
 async function getAccessToken(
@@ -161,6 +182,10 @@ async function getCICDScanQL(
   return await response.readBody();
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // Work around lack of export
 type Summary = ReturnType<typeof core.summary.addRaw>;
 
@@ -193,11 +218,22 @@ export function buildSummary(
     .addLink("View report on Wiz", link);
 }
 
+export function buildFallbackSummary(image: string, scanId: string): Summary {
+  return core.summary
+    .addHeading(`Wiz scan report for ${image}`)
+    .addLink("View report on Wiz", toScanUrl(scanId));
+}
+
 export function toScanUrl(scanId: string): string {
   return `https://app.wiz.io/reports/cicd-scans#~(cicd_scan~'${scanId})`;
 }
 
 // Exported for use in tests
-export function parse(body: string): ScanResult {
-  return (JSON.parse(body) as CICDScanQL).data.cicdScan.resultJSON;
+export function parse(body: string): ScanResult | null {
+  const parsed = JSON.parse(body) as CICDScanQL;
+  const cicdScan = parsed.data?.cicdScan;
+  if (!cicdScan?.resultJSON) {
+    return null;
+  }
+  return cicdScan.resultJSON;
 }

--- a/test/scan-results/cicd-scan-null.json
+++ b/test/scan-results/cicd-scan-null.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "cicdScan": null
+  }
+}


### PR DESCRIPTION
## Summary

Fixes `Error writing summary: Cannot read properties of null (reading 'resultJSON')` when the Wiz GraphQL API returns `cicdScan: null` immediately after a scan completes.

This warning is benign today (scan outputs are still set), but it is noisy and prevents the GitHub step summary from rendering.

## Root cause

`parse()` assumed `data.cicdScan` is always present:

```ts
return (JSON.parse(body) as CICDScanQL).data.cicdScan.resultJSON;
```

When Wiz returns `{ "data": { "cicdScan": null } }` (eventual consistency / scan report not yet available), this throws a `TypeError`.

## Changes

- **`parse()`**: return `null` when `cicdScan` or `resultJSON` is missing (no TypeError)
- **`fetch()`**: retry up to 5 times with 2s delay when `parse()` returns null
- **`main.ts`**: on summary fetch failure, write a fallback step summary with a Wiz report link
- **Tests**: null `cicdScan` fixture + fallback summary test

## Test plan

- [x] `npm test` — all 12 tests pass locally
- [x] CI on this PR

## Context

Observed in production GitHub Actions runs using `freckle/wiz-action@v2.0.7` where the scan completed successfully (`scan-id` and `scan-result` outputs were set) but step summary writing logged the warning above.

Made with [Cursor](https://cursor.com)